### PR TITLE
Fix word detection within same span elements

### DIFF
--- a/src/hooks/useWordDetection.ts
+++ b/src/hooks/useWordDetection.ts
@@ -77,11 +77,6 @@ export const useWordDetection = () => {
           : null) ||
         (target.tagName === 'SPAN' && target.textContent ? target : null);
 
-      // If we're still over the same element, don't recalculate word detection
-      if (textElement === currentElementRef.current && currentWordRef.current) {
-        return;
-      }
-
       // Clear any existing timeout
       if (debounceTimeoutRef.current) {
         clearTimeout(debounceTimeoutRef.current);


### PR DESCRIPTION
## Summary
• Fixed word detection not triggering when moving between different words within the same span element
• Removed optimization that prevented recalculation when mouse remained over the same element
• Now properly detects word changes within the same sentence/span

## Test plan
- [x] Load a PDF with multiple words in the same text span
- [x] Hover over different words within the same sentence
- [x] Verify that tooltips appear for each word correctly
- [x] Confirm no performance issues with increased recalculation

🤖 Generated with [Claude Code](https://claude.ai/code)