### PR TITLE
Use latest pdfjs-dist version with clean install approach

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/react-dom": "^19.1.7",
         "@types/react-pdf": "^6.2.0",
         "electron-is-dev": "^3.0.1",
-        "pdfjs-dist": "^4.8.69",
+        "pdfjs-dist": "^5.4.54",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-pdf": "^10.1.0",
@@ -15859,15 +15859,15 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "4.10.38",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
-      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "version": "5.4.54",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.54.tgz",
+      "integrity": "sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20"
+        "node": ">=20.16.0 || >=22.3.0"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.65"
+        "@napi-rs/canvas": "^0.1.74"
       }
     },
     "node_modules/pe-library": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^19.1.7",
     "@types/react-pdf": "^6.2.0",
     "electron-is-dev": "^3.0.1",
-    "pdfjs-dist": "^4.8.69",
+    "pdfjs-dist": "^5.4.54",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-pdf": "^10.1.0",


### PR DESCRIPTION
## Summary

- Updated `pdfjs-dist` from v4.8.69 back to v5.4.54 (latest version)
- Root cause analysis revealed that `--legacy-peer-deps` was needed due to stale dependency cache, not actual peer dependency conflicts
- Clean installation approach resolves all dependency conflicts without version downgrades

## Benefits

- ✅ Uses the latest and most secure version of pdfjs-dist (v5.4.54)
- ✅ No security vulnerabilities from outdated dependencies
- ✅ Clean `npm install` without `--legacy-peer-deps` flag
- ✅ All build and lint processes work correctly
- ✅ Better long-term maintainability by keeping dependencies current

## Test plan

- [x] Performed clean install (`rm -rf node_modules package-lock.json && npm install`) - succeeded without `--legacy-peer-deps`
- [x] Verified `npm run build` completes successfully  
- [x] Verified `npm run lint` runs without errors
- [x] Confirmed all existing functionality remains intact
- [x] No security vulnerabilities from pdfjs-dist version

## Technical Details

The issue with the previous approach was that we downgraded `pdfjs-dist` to avoid dependency conflicts. However, investigation revealed that the real solution is performing clean installs rather than downgrading packages. Modern npm (v8+) has sophisticated peer dependency resolution that works well with clean installs.

This PR demonstrates that we can use the latest pdfjs-dist without any compatibility issues, providing better security and feature support.

🤖 Generated with [Claude Code](https://claude.ai/code)