### PR TITLE
Update to Gemini 2.5 models and set 2.5 Flash as default

### DIFF
--- a/src/components/SettingsModal/SettingsModal.module.css
+++ b/src/components/SettingsModal/SettingsModal.module.css
@@ -102,6 +102,29 @@
   opacity: 0.7;
 }
 
+.select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 14px;
+  transition: all 0.2s ease;
+  outline: none;
+  box-sizing: border-box;
+  background-color: white;
+}
+
+.select:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.select:disabled {
+  background-color: #f3f4f6;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 .helpText {
   margin-top: 6px;
   font-size: 12px;

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -15,6 +15,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   onSave,
 }) => {
   const [apiKey, setApiKey] = useState('');
+  const [selectedModel, setSelectedModel] = useState('');
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [isSaved, setIsSaved] = useState(false);

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -131,6 +131,28 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
             </div>
           </div>
 
+          <div className={styles.formGroup}>
+            <label htmlFor="selectedModel" className={styles.label}>
+              AI Model
+            </label>
+            <select
+              id="selectedModel"
+              value={selectedModel}
+              onChange={e => setSelectedModel(e.target.value)}
+              className={styles.select}
+              disabled={isValidating}
+            >
+              {AVAILABLE_GEMINI_MODELS.map(model => (
+                <option key={model.id} value={model.id}>
+                  {model.name}
+                </option>
+              ))}
+            </select>
+            <div className={styles.helpText}>
+              {AVAILABLE_GEMINI_MODELS.find(m => m.id === selectedModel)?.description}
+            </div>
+          </div>
+
           {validationError && (
             <div className={styles.errorMessage}>{validationError}</div>
           )}

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -1,5 +1,8 @@
 import React, {useState, useEffect} from 'react';
-import {settingsService, AVAILABLE_GEMINI_MODELS} from '../../services/settingsService';
+import {
+  settingsService,
+  AVAILABLE_GEMINI_MODELS,
+} from '../../services/settingsService';
 import {geminiService} from '../../services/geminiService';
 import styles from './SettingsModal.module.css';
 
@@ -149,7 +152,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
               ))}
             </select>
             <div className={styles.helpText}>
-              {AVAILABLE_GEMINI_MODELS.find(m => m.id === selectedModel)?.description}
+              {
+                AVAILABLE_GEMINI_MODELS.find(m => m.id === selectedModel)
+                  ?.description
+              }
             </div>
           </div>
 

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -24,6 +24,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
     if (isOpen) {
       const currentSettings = settingsService.loadSettings();
       setApiKey(currentSettings.geminiApiKey);
+      setSelectedModel(currentSettings.selectedModel);
       setValidationError(null);
       setIsSaved(false);
     }

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -55,6 +55,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
       }
 
       settingsService.updateGeminiApiKey(apiKey.trim());
+      settingsService.updateSelectedModel(selectedModel);
       setIsSaved(true);
 
       setTimeout(() => {

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {settingsService} from '../../services/settingsService';
+import {settingsService, AVAILABLE_GEMINI_MODELS} from '../../services/settingsService';
 import {geminiService} from '../../services/geminiService';
 import styles from './SettingsModal.module.css';
 

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -56,7 +56,8 @@ class GeminiService {
   async sendMessage(message: string, pdfContext?: string): Promise<string> {
     try {
       const genAI = this.getInitializedClient();
-      const model = genAI.getGenerativeModel({model: 'gemini-1.5-flash'});
+      const selectedModelId = settingsService.getSelectedModel();
+      const model = genAI.getGenerativeModel({model: selectedModelId});
 
       let prompt = message;
       if (pdfContext) {

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -94,7 +94,10 @@ class SettingsService {
 
   getSelectedModelInfo(): GeminiModel {
     const modelId = this.getSelectedModel();
-    return AVAILABLE_GEMINI_MODELS.find(model => model.id === modelId) || DEFAULT_GEMINI_MODEL;
+    return (
+      AVAILABLE_GEMINI_MODELS.find(model => model.id === modelId) ||
+      DEFAULT_GEMINI_MODEL
+    );
   }
 
   clearSettings(): void {

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -39,6 +39,7 @@ class SettingsService {
         const parsed = JSON.parse(stored);
         return {
           geminiApiKey: parsed.geminiApiKey || '',
+          selectedModel: parsed.selectedModel || DEFAULT_GEMINI_MODEL.id,
         };
       }
     } catch (error) {
@@ -47,6 +48,7 @@ class SettingsService {
 
     return {
       geminiApiKey: '',
+      selectedModel: DEFAULT_GEMINI_MODEL.id,
     };
   }
 

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -6,19 +6,14 @@ export interface GeminiModel {
 
 export const AVAILABLE_GEMINI_MODELS: GeminiModel[] = [
   {
-    id: 'gemini-1.5-flash',
-    name: 'Gemini 1.5 Flash',
-    description: 'Fast and efficient model for quick responses',
+    id: 'gemini-2.5-flash',
+    name: 'Gemini 2.5 Flash',
+    description: 'Fast and efficient model with improved performance',
   },
   {
-    id: 'gemini-1.5-pro',
-    name: 'Gemini 1.5 Pro',
-    description: 'More capable model for complex tasks',
-  },
-  {
-    id: 'gemini-pro',
-    name: 'Gemini Pro',
-    description: 'Balanced performance and capability',
+    id: 'gemini-2.5-pro',
+    name: 'Gemini 2.5 Pro',
+    description: 'Most capable model for complex reasoning tasks',
   },
 ];
 

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -79,6 +79,24 @@ class SettingsService {
     return apiKey.length > 0 && apiKey.startsWith('AIza');
   }
 
+  getSelectedModel(): string {
+    const settings = this.loadSettings();
+    return settings.selectedModel;
+  }
+
+  updateSelectedModel(modelId: string): void {
+    const currentSettings = this.loadSettings();
+    this.saveSettings({
+      ...currentSettings,
+      selectedModel: modelId,
+    });
+  }
+
+  getSelectedModelInfo(): GeminiModel {
+    const modelId = this.getSelectedModel();
+    return AVAILABLE_GEMINI_MODELS.find(model => model.id === modelId) || DEFAULT_GEMINI_MODEL;
+  }
+
   clearSettings(): void {
     localStorage.removeItem(this.storageKey);
   }

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -1,5 +1,32 @@
+export interface GeminiModel {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export const AVAILABLE_GEMINI_MODELS: GeminiModel[] = [
+  {
+    id: 'gemini-1.5-flash',
+    name: 'Gemini 1.5 Flash',
+    description: 'Fast and efficient model for quick responses',
+  },
+  {
+    id: 'gemini-1.5-pro',
+    name: 'Gemini 1.5 Pro',
+    description: 'More capable model for complex tasks',
+  },
+  {
+    id: 'gemini-pro',
+    name: 'Gemini Pro',
+    description: 'Balanced performance and capability',
+  },
+];
+
+export const DEFAULT_GEMINI_MODEL = AVAILABLE_GEMINI_MODELS[0];
+
 export interface AppSettings {
   geminiApiKey: string;
+  selectedModel: string;
 }
 
 class SettingsService {


### PR DESCRIPTION
## Summary
- Added Gemini 2.5 Pro and Gemini 2.5 Flash models
- Set Gemini 2.5 Flash as the default model
- Removed support for legacy Gemini 1.x models (1.5-flash, 1.5-pro, gemini-pro)

## Changes
- Updated `settingsService.ts` to include only Gemini 2.5 models
- Changed default model selection to Gemini 2.5 Flash for better performance
- Improved model descriptions to reflect enhanced capabilities

## Test plan
- [ ] Verify that the settings modal displays only Gemini 2.5 models
- [ ] Confirm that Gemini 2.5 Flash is selected by default for new users
- [ ] Test that existing users with legacy model selections gracefully fall back to the default
- [ ] Validate that both models work correctly with the Gemini API

🤖 Generated with [Claude Code](https://claude.ai/code)