### PR TITLE
Add resizable sidebar functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,3 +92,4 @@ docpeak/
 - Avoid class inheritance (except when required by libraries)
 - Don't implement many features at once - work incrementally
 - Always compile and test after modifications
+- Check linter and fix the linter errorr before making pull requests

--- a/src/components/PDFViewer/PDFViewer.module.css
+++ b/src/components/PDFViewer/PDFViewer.module.css
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  margin-right: 320px; /* Make space for sidebar */
   background-color: #f5f5f5;
+  position: relative;
 }
 
 .controls {
@@ -258,4 +258,47 @@
   .documentContainer {
     padding: 1rem;
   }
+}
+
+/* Horizontal Resize Handle Styles */
+.horizontalResizeHandle {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  background: #f8f9fa;
+  border-left: 1px solid #e9ecef;
+  border-right: 1px solid #e9ecef;
+  cursor: ew-resize;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+}
+
+.horizontalResizeHandle:hover {
+  background: #e9ecef;
+}
+
+.horizontalResizeHandle.dragging {
+  background: #dee2e6;
+}
+
+.horizontalResizeBar {
+  height: 40px;
+  width: 2px;
+  background: #adb5bd;
+  border-radius: 1px;
+  transition: all 0.2s ease;
+}
+
+.horizontalResizeHandle:hover .horizontalResizeBar {
+  background: #6c757d;
+  height: 60px;
+}
+
+.horizontalResizeHandle.dragging .horizontalResizeBar {
+  background: #495057;
+  height: 80px;
 }

--- a/src/components/PDFViewer/PDFViewer.tsx
+++ b/src/components/PDFViewer/PDFViewer.tsx
@@ -7,6 +7,7 @@ import {useDictionary} from '../../hooks/useDictionary';
 import {useWordHighlight} from '../../hooks/useWordHighlight';
 import {usePDFTextExtraction} from '../../hooks/usePDFTextExtraction';
 import {useChat} from '../../hooks/useChat';
+import useHorizontalResizable from '../../hooks/useHorizontalResizable';
 import Sidebar from '../Sidebar';
 import SettingsModal from '../SettingsModal';
 import styles from './PDFViewer.module.css';
@@ -33,6 +34,16 @@ const PDFViewer: React.FC<PDFViewerProps> = ({fileUrl}) => {
   const [viewMode, setViewMode] = useState<'single' | 'all'>('all');
   const [containerWidth, setContainerWidth] = useState<number>(0);
   const [isSettingsOpen, setIsSettingsOpen] = useState<boolean>(false);
+
+  const {
+    width: sidebarWidth,
+    isDragging,
+    handleMouseDown,
+  } = useHorizontalResizable({
+    initialWidth: 400,
+    minWidth: 300,
+    maxWidth: 600,
+  });
 
   const {hoveredWord} = useWordDetection();
   const {definition, loading, error, fetchDefinition, clearDefinition} =
@@ -162,7 +173,10 @@ const PDFViewer: React.FC<PDFViewerProps> = ({fileUrl}) => {
   }
 
   return (
-    <div className={styles.container}>
+    <div
+      className={styles.container}
+      style={{marginRight: `${sidebarWidth}px`}}
+    >
       <div className={styles.controls}>
         <button onClick={toggleViewMode} className={styles.viewModeButton}>
           {viewMode === 'all' ? 'Show Single Page' : 'Show All Pages'}
@@ -246,7 +260,16 @@ const PDFViewer: React.FC<PDFViewerProps> = ({fileUrl}) => {
         </Document>
       </div>
 
+      <div
+        className={`${styles.horizontalResizeHandle} ${isDragging ? styles.dragging : ''}`}
+        style={{right: `${sidebarWidth}px`}}
+        onMouseDown={handleMouseDown}
+      >
+        <div className={styles.horizontalResizeBar} />
+      </div>
+
       <Sidebar
+        width={sidebarWidth}
         definition={definition}
         loading={loading}
         error={error}

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -1,5 +1,4 @@
 .sidebar {
-  width: 320px;
   height: 100vh;
   background: #f8f9fa;
   border-left: 1px solid #e9ecef;
@@ -15,18 +14,18 @@
 }
 
 .dictionarySection {
-  flex: 1;
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  min-height: 200px;
   border-bottom: 1px solid #e9ecef;
+  background: #f8f9fa;
 }
 
 .chatSection {
   flex: 1;
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  min-height: 200px;
   background: #ffffff;
 }
 
@@ -219,4 +218,44 @@
   color: #2c3e50;
   flex: 1;
   font-size: 15px;
+}
+
+/* Resize Handle Styles */
+.resizeHandle {
+  height: 8px;
+  background: #f8f9fa;
+  border-top: 1px solid #e9ecef;
+  border-bottom: 1px solid #e9ecef;
+  cursor: ns-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: background-color 0.2s ease;
+}
+
+.resizeHandle:hover {
+  background: #e9ecef;
+}
+
+.resizeHandle.dragging {
+  background: #dee2e6;
+}
+
+.resizeBar {
+  width: 40px;
+  height: 2px;
+  background: #adb5bd;
+  border-radius: 1px;
+  transition: all 0.2s ease;
+}
+
+.resizeHandle:hover .resizeBar {
+  background: #6c757d;
+  width: 60px;
+}
+
+.resizeHandle.dragging .resizeBar {
+  background: #495057;
+  width: 80px;
 }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import {WordDefinition} from '../../services/dictionaryService';
 import {ChatMessage} from '../../services/geminiService';
 import ChatWindow from '../ChatWindow';
+import useResizable from '../../hooks/useResizable';
 import styles from './Sidebar.module.css';
 
 interface SidebarProps {
+  width: number;
   definition: WordDefinition | null;
   loading: boolean;
   error: string | null;
@@ -19,6 +21,7 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
+  width,
   definition,
   loading,
   error,
@@ -31,9 +34,22 @@ const Sidebar: React.FC<SidebarProps> = ({
   onClearChatError,
   onOpenSettings,
 }) => {
+  const {
+    height: dictionaryHeight,
+    isDragging,
+    handleMouseDown,
+  } = useResizable({
+    initialHeight: window.innerHeight / 2,
+    minHeight: 200,
+    maxHeight: window.innerHeight - 200,
+  });
+
   return (
-    <div className={styles.sidebar}>
-      <div className={styles.dictionarySection}>
+    <div className={styles.sidebar} style={{width: `${width}px`}}>
+      <div
+        className={styles.dictionarySection}
+        style={{height: `${dictionaryHeight}px`}}
+      >
         <div className={styles.header}>
           <h2 className={styles.title}>Dictionary</h2>
         </div>
@@ -95,6 +111,13 @@ const Sidebar: React.FC<SidebarProps> = ({
             </div>
           )}
         </div>
+      </div>
+
+      <div
+        className={`${styles.resizeHandle} ${isDragging ? styles.dragging : ''}`}
+        onMouseDown={handleMouseDown}
+      >
+        <div className={styles.resizeBar} />
       </div>
 
       <div className={styles.chatSection}>

--- a/src/hooks/useHorizontalResizable.ts
+++ b/src/hooks/useHorizontalResizable.ts
@@ -1,0 +1,78 @@
+import {useState, useCallback, useEffect, useRef} from 'react';
+
+interface UseHorizontalResizableOptions {
+  initialWidth: number;
+  minWidth?: number;
+  maxWidth?: number;
+}
+
+interface UseHorizontalResizableReturn {
+  width: number;
+  isDragging: boolean;
+  handleMouseDown: (event: React.MouseEvent) => void;
+}
+
+export const useHorizontalResizable = ({
+  initialWidth,
+  minWidth = 250,
+  maxWidth = window.innerWidth - 300,
+}: UseHorizontalResizableOptions): UseHorizontalResizableReturn => {
+  const [width, setWidth] = useState(initialWidth);
+  const [isDragging, setIsDragging] = useState(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      setIsDragging(true);
+      startXRef.current = event.clientX;
+      startWidthRef.current = width;
+    },
+    [width],
+  );
+
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      if (!isDragging) return;
+
+      const deltaX = startXRef.current - event.clientX; // Reverse delta for right-side panel
+      const newWidth = startWidthRef.current + deltaX;
+
+      // Apply constraints
+      const constrainedWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
+
+      setWidth(constrainedWidth);
+    },
+    [isDragging, minWidth, maxWidth],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      document.body.style.cursor = 'ew-resize';
+      document.body.style.userSelect = 'none';
+
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+    }
+    return undefined;
+  }, [isDragging, handleMouseMove, handleMouseUp]);
+
+  return {
+    width,
+    isDragging,
+    handleMouseDown,
+  };
+};
+
+export default useHorizontalResizable;

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -1,0 +1,81 @@
+import {useState, useCallback, useEffect, useRef} from 'react';
+
+interface UseResizableOptions {
+  initialHeight: number;
+  minHeight?: number;
+  maxHeight?: number;
+}
+
+interface UseResizableReturn {
+  height: number;
+  isDragging: boolean;
+  handleMouseDown: (event: React.MouseEvent) => void;
+}
+
+export const useResizable = ({
+  initialHeight,
+  minHeight = 100,
+  maxHeight = window.innerHeight - 200,
+}: UseResizableOptions): UseResizableReturn => {
+  const [height, setHeight] = useState(initialHeight);
+  const [isDragging, setIsDragging] = useState(false);
+  const startYRef = useRef(0);
+  const startHeightRef = useRef(0);
+
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      setIsDragging(true);
+      startYRef.current = event.clientY;
+      startHeightRef.current = height;
+    },
+    [height],
+  );
+
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      if (!isDragging) return;
+
+      const deltaY = event.clientY - startYRef.current;
+      const newHeight = startHeightRef.current + deltaY;
+
+      // Apply constraints
+      const constrainedHeight = Math.max(
+        minHeight,
+        Math.min(maxHeight, newHeight),
+      );
+
+      setHeight(constrainedHeight);
+    },
+    [isDragging, minHeight, maxHeight],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      document.body.style.cursor = 'ns-resize';
+      document.body.style.userSelect = 'none';
+
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+    }
+    return undefined;
+  }, [isDragging, handleMouseMove, handleMouseUp]);
+
+  return {
+    height,
+    isDragging,
+    handleMouseDown,
+  };
+};
+
+export default useResizable;


### PR DESCRIPTION
## Summary
- Add horizontal resize handle between PDF viewer and sidebar (dictionary + chat)
- Add vertical resize handle between dictionary and chat sections within sidebar
- Implement dynamic width adjustment (300-600px) and height adjustment with proper constraints

## Test plan
- [ ] Verify horizontal resize handle appears between PDF and sidebar
- [ ] Test left-right dragging to adjust sidebar width (300-600px range)
- [ ] Verify vertical resize handle appears between dictionary and chat sections
- [ ] Test up-down dragging to adjust section heights (min 200px each)
- [ ] Confirm proper cursor changes during drag operations
- [ ] Test that layout remains responsive and functional after resizing

🤖 Generated with [Claude Code](https://claude.ai/code)