### PR TITLE
Fix Japanese input IME Enter key handling

### DIFF
--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -41,6 +41,10 @@ const ChatWindow: React.FC<ChatWindowProps> = ({
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
+      // Only send message when not in IME composition
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       e.preventDefault();
       handleSubmit(e);
     }


### PR DESCRIPTION
## Summary
- Fixed issue where Enter key during Japanese IME composition would incorrectly send messages
- Added `e.nativeEvent.isComposing` check to distinguish between IME conversion confirmation and message submission
- Prevents accidental message sending during hiragana-to-kanji conversion

## Test plan
- [x] Test Japanese input with IME (hiragana to kanji conversion)
- [x] Verify Enter during conversion does not send message
- [x] Verify Enter after conversion properly sends message
- [ ] Test with other languages and input methods

🤖 Generated with [Claude Code](https://claude.ai/code)