### PR TITLE
Add AI model display to sidebar header

### DIFF
--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -31,11 +31,35 @@
 
 .chatHeader {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   padding: 8px 12px;
   background: #f8f9fa;
   border-bottom: 1px solid #e9ecef;
+}
+
+.aiModelInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.aiModelLabel {
+  font-size: 11px;
+  color: #6c757d;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 500;
+}
+
+.aiModelName {
+  font-size: 13px;
+  color: #495057;
+  font-weight: 600;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settingsButton {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {WordDefinition} from '../../services/dictionaryService';
 import {ChatMessage} from '../../services/geminiService';
+import {settingsService} from '../../services/settingsService';
 import ChatWindow from '../ChatWindow';
 import useResizable from '../../hooks/useResizable';
 import styles from './Sidebar.module.css';
@@ -43,6 +44,19 @@ const Sidebar: React.FC<SidebarProps> = ({
     minHeight: 200,
     maxHeight: window.innerHeight - 200,
   });
+
+  // Get current AI model information
+  const settings = settingsService.loadSettings();
+  const currentModel = settingsService
+    .getAvailableModelsForProvider(settings.providerType)
+    .find(model => model.id === settings.selectedModel);
+
+  const baseModelName =
+    currentModel?.name || settings.selectedModel || 'Unknown Model';
+  const modelDisplayName =
+    settings.providerType === 'ollama'
+      ? `Ollama - ${baseModelName}`
+      : baseModelName;
 
   return (
     <div className={styles.sidebar} style={{width: `${width}px`}}>
@@ -122,6 +136,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 
       <div className={styles.chatSection}>
         <div className={styles.chatHeader}>
+          <div className={styles.aiModelInfo}>
+            <span className={styles.aiModelLabel}>AI Model:</span>
+            <span className={styles.aiModelName}>{modelDisplayName}</span>
+          </div>
           <button
             className={styles.settingsButton}
             onClick={onOpenSettings}


### PR DESCRIPTION
## Summary
- Add current AI model name display in sidebar chat header
- Show provider-specific formatting (Ollama prefix for local models)
- Position AI model info alongside settings button for easy visibility

## Changes
- Modified `Sidebar.tsx` to fetch and display current AI model information
- Added responsive CSS styling for AI model display in chat header
- Implemented provider-specific formatting (Ollama vs other providers)

## Test plan
- [x] Verify AI model name appears in sidebar header
- [x] Test with different providers (Gemini and Ollama)
- [x] Confirm responsive design works with long model names
- [x] Ensure settings button remains accessible
- [x] Build passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)